### PR TITLE
Return entryCardsEditor widget for unions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .cpcache/
 .nrepl-port
 target/
+.idea/
+hodur-contentful.iml

--- a/src/hodur_contentful_schema/core.clj
+++ b/src/hodur_contentful_schema/core.clj
@@ -178,9 +178,12 @@
     "assetLinksEditor"))
 
 (defmethod get-field-widget "Entry" [field]
-  (if (= :one (field-card-type field))
-    "entryLinkEditor"
-    "entryLinksEditor"))
+  (if-let [widget-id (:contentful/widget-id field)]
+    widget-id
+    (if (= :one (field-card-type field))
+      "entryLinkEditor"
+      "entryLinksEditor")))
+
 
 (defmethod get-field-widget :default [{:keys [contentful/widget-id]}] widget-id)
 


### PR DESCRIPTION
If a model is the type of a union, the entryCardsEditor widget option should not return entryLinksEditor.